### PR TITLE
Zemu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
 ]
 
 exclude = [
-  "examples/wasm"
+  "examples/wasm",
+  "examples/zemu-grpc-server",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "ledger-apdu",
     "ledger-transport",
     "ledger-transport-hid",
+    "ledger-transport-zemu",
     "ledger-zondax-generic"
 ]
 

--- a/examples/zemu-grpc-server/Cargo.toml
+++ b/examples/zemu-grpc-server/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zemu-grpc-server"
+version = "0.1.0"
+authors = ["linfeng <linfeng@crypto.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+env_logger = "0.7"
+ledger-zemu = { package = "ledger-transport-zemu", path = "../../ledger-transport-zemu" }

--- a/examples/zemu-grpc-server/src/main.rs
+++ b/examples/zemu-grpc-server/src/main.rs
@@ -1,0 +1,9 @@
+use ledger_zemu::ZemuGrpcServer;
+
+fn main() {
+    env_logger::init();
+    let zemu_http_host = "127.0.0.1".into();
+    let zemu_http_port = 9998;
+    let server = ZemuGrpcServer::new(3002, zemu_http_host, zemu_http_port);
+    server.run();
+}

--- a/ledger-transport-hid/src/errors.rs
+++ b/ledger-transport-hid/src/errors.rs
@@ -25,7 +25,7 @@ pub enum LedgerHIDError {
     Comm(&'static str),
     /// Ioctl error
     #[error("Ledger device: Ioctl error")]
-    Ioctl(#[from] nix::Error),
+    Ioctl(#[from] crate::nix::Error),
     /// i/o error
     #[error("Ledger device: i/o error")]
     Io(#[from] std::io::Error),

--- a/ledger-transport-zemu/.gitignore
+++ b/ledger-transport-zemu/.gitignore
@@ -1,0 +1,2 @@
+zemu.rs
+zemu_grpc.rs

--- a/ledger-transport-zemu/Cargo.toml
+++ b/ledger-transport-zemu/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "ledger-transport-zemu"
+description = "Ledger Zemu Wallet - Zemu Transport"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Linfeng Yuan <linfeng@crypto.com>"]
+homepage = "https://github.com/zondax/ledger-rs"
+repository = "https://github.com/zondax/ledger-rs"
+readme = "README.md"
+categories  = ["authentication", "cryptography", "zemu"]
+keywords = ["ledger", "nano", "blue", "apdu", "zemu"]
+edition = "2018"
+autobenches = false
+
+[badges]
+circle-ci = { repository = "zondax/ledger-rs" }
+
+[lib]
+name = "ledger_zemu"
+
+[dependencies]
+thiserror = "1.0.20"
+log = "0.4.11"
+protobuf = "2"
+grpc = "0.8.1"
+grpc-protobuf = "0.8.1"
+reqwest = { version = "0.10", features = ["json"]}
+hex = "0.4.2"
+serde = { version = "1.0", features = ["derive"] }
+ledger-apdu = { path = "../ledger-apdu", version = "0.4.0" }
+
+[build-dependencies]
+protoc-rust-grpc = "0.8.1"
+

--- a/ledger-transport-zemu/Cargo.toml
+++ b/ledger-transport-zemu/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.11"
 protobuf = "2"
 grpc = "0.8.1"
 grpc-protobuf = "0.8.1"
-reqwest = { version = "0.10", features = ["json"]}
+reqwest = "0.9"
 hex = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 ledger-apdu = { path = "../ledger-apdu", version = "0.4.0" }

--- a/ledger-transport-zemu/build.rs
+++ b/ledger-transport-zemu/build.rs
@@ -1,0 +1,10 @@
+use protoc_rust_grpc::Codegen;
+
+fn main() {
+    Codegen::new()
+        .out_dir("src")
+        .input("zemu.proto")
+        .rust_protobuf(true)
+        .run()
+        .expect("protoc-rust-grpc");
+}

--- a/ledger-transport-zemu/src/errors.rs
+++ b/ledger-transport-zemu/src/errors.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LedgerZemuError {
+    /// Device not found error
+    #[error("Ledger connect error")]
+    ConnectError,
+    /// zemu reponse error
+    #[error("Zemu response error")]
+    ResponseError,
+    /// Inner error
+    #[error("Ledger inner error")]
+    InnerError,
+}

--- a/ledger-transport-zemu/src/lib.rs
+++ b/ledger-transport-zemu/src/lib.rs
@@ -1,0 +1,107 @@
+mod errors;
+mod zemu;
+mod zemu_grpc;
+
+use grpc::prelude::*;
+use grpc::ClientConf;
+use ledger_apdu::{APDUAnswer, APDUCommand};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
+use reqwest::{Client as HttpClient, Response};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use zemu::ExchangeRequest;
+use zemu_grpc::ZemuCommandClient;
+
+use crate::zemu::ExchangeReply;
+pub use errors::LedgerZemuError;
+
+pub struct TransportZemuGrpc {
+    client: ZemuCommandClient,
+}
+
+impl TransportZemuGrpc {
+    pub fn new(host: &str, port: u16) -> Result<Self, LedgerZemuError> {
+        let client = ZemuCommandClient::new_plain(host, port, ClientConf::new())
+            .map_err(|_| LedgerZemuError::ConnectError)?;
+        Ok(Self { client })
+    }
+
+    pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, LedgerZemuError> {
+        let mut request = ExchangeRequest::new();
+        request.set_command(command.serialize());
+        let response: ExchangeReply = self
+            .client
+            .exchange(grpc::RequestOptions::new(), request)
+            .drop_metadata()
+            .await
+            .map_err(|e| {
+                log::error!("grpc response error: {:?}", e);
+                LedgerZemuError::ResponseError
+            })?;
+        Ok(APDUAnswer::from_answer(response.reply))
+    }
+}
+
+pub struct TransportZemuHttp {
+    url: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ZemuRequest {
+    apdu_hex: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct ZemuResponse {
+    data: String,
+    error: Option<String>,
+}
+
+impl TransportZemuHttp {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            url: format!("http://{}:{}", host, port),
+        }
+    }
+
+    pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, LedgerZemuError> {
+        let raw_command = hex::encode(command.serialize());
+        let request = ZemuRequest {
+            apdu_hex: raw_command,
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let resp: Response = HttpClient::new()
+            .post(&self.url)
+            .headers(headers)
+            .timeout(Duration::from_secs(5))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| {
+                log::error!("create http client error: {:?}", e);
+                LedgerZemuError::InnerError
+            })?;
+        log::debug!("http response: {:?}", resp);
+
+        if resp.status().is_success() {
+            let result: ZemuResponse = resp.json().await.map_err(|e| {
+                log::error!("error response: {:?}", e);
+                LedgerZemuError::ResponseError
+            })?;
+            if result.error.is_none() {
+                Ok(APDUAnswer::from_answer(
+                    hex::decode(result.data).expect("decode error"),
+                ))
+            } else {
+                Err(LedgerZemuError::ResponseError)
+            }
+        } else {
+            log::error!("error response: {:?}", resp.status());
+            Err(LedgerZemuError::ResponseError)
+        }
+    }
+}

--- a/ledger-transport-zemu/zemu.proto
+++ b/ledger-transport-zemu/zemu.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+//This file needs to be synced with the one of same name in Zemu repo
+
+package ledger_zemu;
+
+service ZemuCommand {
+  rpc Exchange (ExchangeRequest) returns (ExchangeReply) {}
+}
+
+message ExchangeRequest {
+  bytes command = 1;
+}
+
+message ExchangeReply {
+  bytes reply = 1;
+}

--- a/ledger-transport-zemu/zemu.proto
+++ b/ledger-transport-zemu/zemu.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 //This file needs to be synced with the one of same name in Zemu repo
 
-package ledger_zemu;
+package ledger_go;
 
 service ZemuCommand {
   rpc Exchange (ExchangeRequest) returns (ExchangeReply) {}

--- a/ledger-transport/Cargo.toml
+++ b/ledger-transport/Cargo.toml
@@ -24,12 +24,14 @@ lazy_static = "1.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+trait-async = "0.1.24"
 
 ledger-apdu = { path = "../ledger-apdu", version = "0.4.0" }
 
 # For not wasm compilation (native rust) compiling
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ledger-transport-hid = { path = "../ledger-transport-hid", version = "0.4.0" }
+ledger-transport-zemu = { path = "../ledger-transport-zemu", version = "0.1.0" }
 
 # For wasm compiling
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -39,3 +41,4 @@ js-sys = "0.3"
 
 [dev-dependencies]
 sha2 = "0.8"
+

--- a/ledger-transport/src/apdu_transport_native.rs
+++ b/ledger-transport/src/apdu_transport_native.rs
@@ -21,24 +21,18 @@
 #![doc(html_root_url = "https://docs.rs/ledger-filecoin/0.1.0")]
 
 use crate::errors::TransportError;
-use crate::errors::TransportError::APDUExchangeError;
-use futures::future;
+use crate::Exchange;
 use ledger_apdu::{APDUAnswer, APDUCommand};
 
 /// Transport struct for non-wasm arch
-pub struct APDUTransport {
+pub struct APDUTransport<T: Exchange> {
     /// Native rust transport
-    pub transport_wrapper: ledger::TransportNativeHID,
+    pub transport_wrapper: T,
 }
 
-impl APDUTransport {
+impl<T: Exchange> APDUTransport<T> {
     /// Use to talk to the ledger device
     pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
-        let call = self
-            .transport_wrapper
-            .exchange(command)
-            .map_err(|_| APDUExchangeError)?;
-
-        future::ready(Ok(call)).await
+        self.transport_wrapper.exchange(command).await
     }
 }

--- a/ledger-transport/src/lib.rs
+++ b/ledger-transport/src/lib.rs
@@ -66,12 +66,3 @@ impl Exchange for ledger_zemu::TransportZemuGrpc {
             .map_err(|_| TransportError::APDUExchangeError)
     }
 }
-
-#[trait_async]
-impl Exchange for ledger_zemu::TransportZemuHttp {
-    async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
-        self.exchange(command)
-            .await
-            .map_err(|_| TransportError::APDUExchangeError)
-    }
-}

--- a/ledger-transport/src/lib.rs
+++ b/ledger-transport/src/lib.rs
@@ -19,7 +19,9 @@
 #![deny(unused_import_braces, unused_qualifications)]
 #![deny(missing_docs)]
 
+use futures::future;
 pub use ledger_apdu::{APDUAnswer, APDUCommand, APDUErrorCodes};
+use trait_async::trait_async;
 
 /// APDU Errors
 pub mod errors;
@@ -37,3 +39,39 @@ pub mod apdu_transport_native;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::apdu_transport_native::APDUTransport;
+use crate::errors::TransportError;
+
+/// Use to talk to the ledger device
+#[trait_async]
+pub trait Exchange: Send + Sync {
+    /// Use to talk to the ledger device
+    async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError>;
+}
+
+#[trait_async]
+impl Exchange for ledger::TransportNativeHID {
+    async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
+        let call = self
+            .exchange(command)
+            .map_err(|_| TransportError::APDUExchangeError)?;
+        future::ready(Ok(call)).await
+    }
+}
+
+#[trait_async]
+impl Exchange for ledger_zemu::TransportZemuGrpc {
+    async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
+        self.exchange(command)
+            .await
+            .map_err(|_| TransportError::APDUExchangeError)
+    }
+}
+
+#[trait_async]
+impl Exchange for ledger_zemu::TransportZemuHttp {
+    async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
+        self.exchange(command)
+            .await
+            .map_err(|_| TransportError::APDUExchangeError)
+    }
+}

--- a/ledger-zondax-generic/src/common.rs
+++ b/ledger-zondax-generic/src/common.rs
@@ -22,7 +22,7 @@
 use crate::LedgerAppError;
 use ledger_apdu::{map_apdu_error_description, APDUAnswer, APDUCommand, APDUErrorCodes};
 use ledger_transport::errors::TransportError;
-use ledger_transport::APDUTransport;
+use ledger_transport::{APDUTransport, Exchange};
 use serde::{Deserialize, Serialize};
 use std::str;
 
@@ -107,7 +107,9 @@ pub struct DeviceInfo {
 }
 
 /// Retrieve the device info
-pub async fn get_device_info(apdu_transport: &APDUTransport) -> Result<DeviceInfo, LedgerAppError> {
+pub async fn get_device_info<T: Exchange>(
+    apdu_transport: &APDUTransport<T>,
+) -> Result<DeviceInfo, LedgerAppError> {
     let command = APDUCommand {
         cla: CLA_DEVICE_INFO,
         ins: INS_DEVICE_INFO,
@@ -160,7 +162,9 @@ pub async fn get_device_info(apdu_transport: &APDUTransport) -> Result<DeviceInf
 }
 
 /// Retrieve the app info
-pub async fn get_app_info(apdu_transport: &APDUTransport) -> Result<AppInfo, LedgerAppError> {
+pub async fn get_app_info<T: Exchange>(
+    apdu_transport: &APDUTransport<T>,
+) -> Result<AppInfo, LedgerAppError> {
     let command = APDUCommand {
         cla: CLA_APP_INFO,
         ins: INS_APP_INFO,
@@ -213,9 +217,9 @@ pub async fn get_app_info(apdu_transport: &APDUTransport) -> Result<AppInfo, Led
 }
 
 /// Retrieve the app version
-pub async fn get_version(
+pub async fn get_version<T: Exchange>(
     cla: u8,
-    apdu_transport: &APDUTransport,
+    apdu_transport: &APDUTransport<T>,
 ) -> Result<Version, LedgerAppError> {
     let command = APDUCommand {
         cla,
@@ -283,8 +287,8 @@ pub async fn get_version(
 }
 
 /// Stream a long request in chunks
-pub async fn send_chunks(
-    apdu_transport: &APDUTransport,
+pub async fn send_chunks<T: Exchange>(
+    apdu_transport: &APDUTransport<T>,
     start_command: &APDUCommand,
     message: &[u8],
 ) -> Result<APDUAnswer, LedgerAppError> {


### PR DESCRIPTION
### Description

In this pull request, the following changes are made:

1. Added a new Rust project `zemu-grpc-server` which includes a server implementation for Zemu. This includes additions to the `Cargo.toml`, `src/main.rs`, `zemu.rs`, `zemu_grpc.rs`, and a new `.proto` file.

2. Added a new Rust project `ledger-transport-zemu` which includes a Zemu transport implementation. This includes additions to the `Cargo.toml`, `build.rs`, `src/errors.rs`, `src/lib.rs`, and a `.proto` file.

3. Updated the dependencies and exclusions in the `Cargo.toml` of various related projects including `Cargo.toml` in the `ledger-transport`, `ledger-zondax-generic`, and `ledger-apdu` projects.

4. Modified the `ledger-transport/src/apdu_transport_native.rs` and `ledger-transport/src/lib.rs` files to implement changes related to Zemu transport.

5. Added a new `.gitignore` file for `ledger-transport-zemu` project.

6. Updated code in various files related to defining structs, handling errors, and implementing functionalities for the Zemu Grpc server and transport.

7. Updated code for defining traits and async functions related to Zemu transport implementation.

8. Added new functions for interacting with the Zemu device such as getting device info, app info, and version.

The code changes are focused on adding support for Zemu transport in the project and implementing the necessary functionalities for interaction with the Zemu Grpc server.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for Zemu devices by introducing a new gRPC-based transport layer and server. Refactor existing transport code to be more modular and extensible by using a generic `Exchange` trait. Implement necessary error handling and build configurations for the new transport module.

New Features:
- Introduce a new `TransportZemuGrpc` struct to facilitate communication with Zemu devices using gRPC.
- Add a `ZemuGrpcServer` to handle gRPC requests and forward them to Zemu devices via HTTP.
- Implement the `Exchange` trait for `TransportZemuGrpc` and `TransportNativeHID` to standardize APDU command exchanges.

Enhancements:
- Refactor `APDUTransport` to be generic over any type implementing the `Exchange` trait, allowing for more flexible transport implementations.

Build:
- Add a build script `build.rs` for the `ledger-transport-zemu` module to generate Rust code from the `zemu.proto` file using `protoc-rust-grpc`.

<!-- Generated by sourcery-ai[bot]: end summary -->